### PR TITLE
Use Path.absolute() for loading LoRAs instead of Path.resolve()

### DIFF
--- a/diffusers_nodes_library/common/parameters/file_path_parameter.py
+++ b/diffusers_nodes_library/common/parameters/file_path_parameter.py
@@ -41,6 +41,7 @@ class FilePathParameter:
         )
 
     def get_file_path(self) -> Path:
+        # Use absolute() rather than resolve() to preserve symlinks.
         return Path(self._node.get_parameter_value(self._parameter_name)).absolute()
 
     def validate_parameter_values(self) -> None:

--- a/diffusers_nodes_library/common/utils/lora_utils.py
+++ b/diffusers_nodes_library/common/utils/lora_utils.py
@@ -30,6 +30,9 @@ class LorasParameter:
 
     def to_adapter_name(self, model_path: str) -> str:
         """Returns a unique name for an adapter given its model path."""
+        # Use resolve() here (not absolute()) so that symlinks and their targets
+        # hash to the same adapter name, preventing the same file from being
+        # loaded twice when referenced via different paths.
         resolved = str(Path(model_path).resolve())
         return hashlib.sha256(resolved.encode("utf-8")).hexdigest()
 


### PR DESCRIPTION
LoRA files are often symlinks to blobs with no file extension. Path.resolve() was following the symlink to the blob, losing the .safetensors extension, and the editor was treating that as a directory.

Switching to Path.absolute() preserves the symlink/extension. Adapter dedupe still resolves before hashing so the same LoRA doesn't get loaded twice

Closes https://github.com/griptape-ai/griptape-nodes/issues/4162