### PR TITLE
chore: bump version to v0.67.0

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -28,7 +28,7 @@
     "metadata": {
         "author": "Griptape, Inc.",
         "description": "Advanced media generation and manipulation nodes for Griptape Nodes.",
-        "library_version": "0.66.8",
+        "library_version": "0.67.0",
         "engine_version": "0.77.5",
         "tags": [
             "Griptape",


### PR DESCRIPTION
Considering its been 2 months since last release, a minor version seems OK