### PR TITLE
fix(depthcrafter): chunk 32-bit-index-limited ops so 1080p videos process

### DIFF
--- a/diffusers_nodes_library/common/parameters/diffusion/depthcrafter/depthcrafter_pipeline.py
+++ b/diffusers_nodes_library/common/parameters/diffusion/depthcrafter/depthcrafter_pipeline.py
@@ -42,8 +42,10 @@ class DepthCrafterVideoDiffusionPipeline(diffusers.StableVideoDiffusionPipeline)
         :return: image_embeddings in shape of [b, 1024]
         """
         # Chunk the resize to avoid exceeding 32-bit index limits on high-res, long videos.
+        # Budget half the limit: the antialiasing gaussian blur reflect-pads each frame
+        # before convolving, so the intermediate tensor is larger than the chunk itself.
         elements_per_frame = video.shape[1] * video.shape[2] * video.shape[3]
-        resize_chunk_size = max(1, MAX_CUDA_TENSOR_ELEMENTS // elements_per_frame)
+        resize_chunk_size = max(1, (MAX_CUDA_TENSOR_ELEMENTS // 2) // elements_per_frame)
 
         resized_chunks = []
         for i in range(0, video.shape[0], resize_chunk_size):
@@ -171,9 +173,10 @@ class DepthCrafterVideoDiffusionPipeline(diffusers.StableVideoDiffusionPipeline)
         video = video.to(device=device, dtype=self.dtype)  # pyright: ignore[reportAttributeAccessIssue]
 
         # Compute max frames per chunk to keep CUDA kernel operations under the
-        # 32-bit index limit (2^31 - 1 elements per tensor).
+        # 32-bit index limit (2^31 - 1 elements per tensor). Budget half the limit
+        # for headroom on kernel intermediates.
         elements_per_frame = video.shape[1] * video.shape[2] * video.shape[3]
-        safe_chunk_frames = max(1, MAX_CUDA_TENSOR_ELEMENTS // elements_per_frame)
+        safe_chunk_frames = max(1, (MAX_CUDA_TENSOR_ELEMENTS // 2) // elements_per_frame)
 
         # Normalize [0,1] -> [-1,1] in chunks.
         for i in range(0, num_frames, safe_chunk_frames):

--- a/diffusers_nodes_library/common/parameters/diffusion/depthcrafter/depthcrafter_runtime_parameters.py
+++ b/diffusers_nodes_library/common/parameters/diffusion/depthcrafter/depthcrafter_runtime_parameters.py
@@ -13,6 +13,9 @@ from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.files.project_file import ProjectFileDestination
 from PIL import Image
 
+from diffusers_nodes_library.common.parameters.diffusion.depthcrafter.depthcrafter_pipeline import (
+    MAX_CUDA_TENSOR_ELEMENTS,
+)
 from diffusers_nodes_library.common.parameters.diffusion.runtime_parameters import (
     DiffusionPipelineRuntimeParameters,
 )
@@ -289,12 +292,24 @@ class DepthCrafterPipelineRuntimeParameters(DiffusionPipelineRuntimeParameters):
                 f"Resizing output from {width}x{height} back to {orig_width}x{orig_height}\n"
             )
             depth_tensor = depth_frames.permute(0, 3, 1, 2)  # [B, C, H, W]
-            depth_tensor = torch.nn.functional.interpolate(
-                depth_tensor,
-                size=(orig_height, orig_width),
-                mode="bilinear",
-                align_corners=False,
-            )
+            # Interpolate in frame chunks: the upsample CUDA kernel requires both its
+            # input and output tensors to fit 32-bit indexing (2^31 - 1 elements), and
+            # a full-length high-res video exceeds that. Halve the budget for headroom
+            # on kernel intermediates. Each frame resizes independently, so chunking
+            # along the frame axis is exact.
+            channels = depth_tensor.shape[1]
+            elements_per_frame = channels * max(height * width, orig_height * orig_width)
+            chunk_frames = max(1, (MAX_CUDA_TENSOR_ELEMENTS // 2) // elements_per_frame)
+            resized_chunks = []
+            for i in range(0, depth_tensor.shape[0], chunk_frames):
+                resized_chunk = torch.nn.functional.interpolate(
+                    depth_tensor[i : i + chunk_frames],
+                    size=(orig_height, orig_width),
+                    mode="bilinear",
+                    align_corners=False,
+                )
+                resized_chunks.append(resized_chunk)
+            depth_tensor = torch.cat(resized_chunks, dim=0)
             depth_frames = depth_tensor.permute(0, 2, 3, 1)  # [B, H, W, C]
 
         # Convert to PIL images


### PR DESCRIPTION
Fixes #92

## The bug in one sentence

DepthCrafter crashes on any video where **total pixels across the whole clip** (frames × 3 channels × height × width) exceeds ~2.1 billion, because two spots in our code hand the *entire video* (or too big a slice of it) to PyTorch CUDA kernels that refuse tensors that large.

## Scenarios: what happens before vs. after this PR

| # | Artist does... | Before this PR | After this PR |
|---|---|---|---|
| 1 | Runs a **short** 1920x1080 clip (≤ ~340 frames) with `force_size` on | ✅ Works (fits under the limit by luck) | ✅ Works, unchanged output |
| 2 | Runs a **long** 1920x1080 clip (e.g. the 361-frame repro) with `force_size` on | ❌ Crashes with `Expected canUse32BitIndexMath(input) && canUse32BitIndexMath(output) to be true, but got false` | ✅ Works |
| 3 | Pre-resizes to 1920x1088 themselves (a valid multiple of 64), 361 frames, `force_size` irrelevant | ❌ Same crash, from a *different* spot (the CLIP-embedding resize) | ✅ Works |
| 4 | Runs a 1920x1080 clip with `force_size` **off** | ❌ Clean error: "dimensions are not multiples of 64" | ❌ Same clean error — intentional, unchanged |
| 5 | Runs a very long clip (1000+ frames of 1080p) | ❌ Crash | ✅ Works — no frame-count ceiling anymore (VRAM permitting, as always) |
| 6 | Runs any clip that already worked | ✅ Works | ✅ Bit-identical output (see "Why this is safe") |

Note scenario 4 is not a bug: the multiple-of-64 requirement is real, and `force_size` is the escape hatch. The bug was that the escape hatch (scenario 2) traded the clean error for a crash.

## Why it crashed

PyTorch CUDA kernels mostly use 32-bit indexing for speed, so any single tensor they touch must have ≤ 2³¹−1 (~2.147B) elements. Most ops transparently split bigger tensors; a few — `interpolate` (resize) and `reflection_pad2d` among them — just abort with the `canUse32BitIndexMath` error. We can't opt into 64-bit; it's an upstream PyTorch limitation (the error message itself says to file a PyTorch enhancement request).

361 frames × 3 channels × 1088 × 1920 = **2.26B elements** — over the limit. Two places tripped it:

1. **The output resize-back** (`depthcrafter_runtime_parameters.py`): after depth estimation, when `force_size` had stretched 1080→1088, we resized the depth video back to 1080 with **one `interpolate` call over the entire clip**. 2.26B elements in, 2.25B out → crash. This is scenario 2.
2. **The CLIP-embedding resize** (`depthcrafter_pipeline.py`, `encode_video`): this already chunked frames to stay under the limit, but budgeted 100% of it (342 frames = 99.8% full). The antialiasing blur inside diffusers then reflect-pads each frame (+6 rows, +14 cols at this scale), inflating the padded intermediate to 2.17B → crash. This is scenario 3, and also why scenario 2 couldn't be fixed by the resize-back alone.

## The fix

Slice along the **time axis**, never the pixels:

- The resize-back now processes the clip in batches of frames (171 at a time for 1080p) instead of all at once.
- The existing chunk math in `encode_video` and the normalize step now budgets **half** the limit, leaving headroom for padded intermediates.

**No downscaling is introduced.** Every frame stays at full resolution regardless of clip length — a 1-frame clip and a 1000-frame clip both process at 1920x1088; the long one just takes more batches. This mirrors what the pipeline already does elsewhere (`window_size` for denoising, `decode_chunk_size` for the VAE).

## Why this is safe

Each of the chunked operations treats every frame independently — frame 200's resize doesn't look at frame 199. So splitting along time is mathematically identical to one big call, not an approximation. Verified on CPU: chunked output is **bit-identical** (`torch.equal`) to the unchunked call.

## Verification

- `make check` passes (lint/format/pyright clean).
- Chunk math validated at the exact repro shape (1920x1088 × 361 frames): every chunk, including the reflect-pad-inflated intermediates, stays under 2³¹−1, and the chunks cover all 361 frames exactly.
- ⚠️ **Not yet run on GPU** — no CUDA box locally. Needs a validation run on the original `seq300_sh010` clip (or any 350+ frame 1080p video) before merge.

## Out of scope (follow-up)

The stretch-vs-pad question from #92 (force_size currently *stretches* 1080→1088 and back, a ~0.7% vertical resample round-trip; padding 8 rows and cropping them off would leave original pixels untouched) is deliberately not addressed here — it changes output alignment behavior and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)